### PR TITLE
Introduz SupervisionGroup para Service e TileCache.

### DIFF
--- a/lib/such_great_heights.rb
+++ b/lib/such_great_heights.rb
@@ -1,3 +1,11 @@
+module SuchGreatHeights
+  SRTM1_SIDE = 3601
+  SRTM3_SIDE = 1201
+  NO_DATA    = -32_768
+  ARCSECOND  = (1 / 3600.0) # in degrees
+  DEFAULT_TILE_DURATION = 6 * 60 * 60 # hours in seconds
+end
+
 require_relative "such_great_heights/configuration"
 require_relative "such_great_heights/errors"
 require_relative "such_great_heights/srtm_conversions"
@@ -11,14 +19,7 @@ require_relative "such_great_heights/http_handler"
 require_relative "such_great_heights/altitude_response"
 require_relative "such_great_heights/profile_response"
 require_relative "such_great_heights/tile_cache"
+require_relative "such_great_heights/service_supervision_group"
 
 require_relative "such_great_heights/server"
 require_relative "such_great_heights/client"
-
-module SuchGreatHeights
-  SRTM1_SIDE = 3601
-  SRTM3_SIDE = 1201
-  NO_DATA    = -32_768
-  ARCSECOND  = (1 / 3600.0) # in degrees
-  DEFAULT_TILE_DURATION = 6 * 60 * 60 # hours in seconds
-end

--- a/lib/such_great_heights/configuration.rb
+++ b/lib/such_great_heights/configuration.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module SuchGreatHeights
   class Configuration
     def initialize(tile_set_path, tile_duration)
@@ -6,6 +8,10 @@ module SuchGreatHeights
     end
 
     attr_reader :tile_set_path, :tile_duration
+
+    def self.current
+      @configuration ||= load_from_file
+    end
 
     def self.load_from_file
       config = YAML.load(open(configuration_path))

--- a/lib/such_great_heights/server.rb
+++ b/lib/such_great_heights/server.rb
@@ -9,8 +9,8 @@ module SuchGreatHeights
       super host, port, &method(:on_connection)
 
       @clients = []
-      @service = Service.new_link(configuration.tile_set_path,
-                                  configuration.tile_duration)
+
+      ServiceSupervisionGroup.run!
     end
 
     attr_reader :service
@@ -22,7 +22,8 @@ module SuchGreatHeights
       connection.each_request do |request|
         if request.websocket?
           connection.detach
-          @clients << Client.new_link(request.websocket, service)
+          @clients << Client.new_link(request.websocket,
+                                      Celluloid::Actor[:service])
         else
           handle_request(request)
         end
@@ -35,10 +36,6 @@ module SuchGreatHeights
 
     def client_disconnected(client, _)
       @clients.delete(client)
-    end
-
-    def configuration
-      @configuration ||= Configuration.load_from_file
     end
   end
 end

--- a/lib/such_great_heights/service.rb
+++ b/lib/such_great_heights/service.rb
@@ -4,8 +4,8 @@ module SuchGreatHeights
   class Service
     include Celluloid
 
-    def initialize(tile_set, tile_duration, tile_cache: TileCache)
-      @tile_cache = tile_cache.new_link(tile_set, tile_duration)
+    def initialize(tile_cache: Celluloid::Actor[:tile_cache])
+      @tile_cache = tile_cache
     end
 
     attr_reader :tile_cache

--- a/lib/such_great_heights/service_supervision_group.rb
+++ b/lib/such_great_heights/service_supervision_group.rb
@@ -1,0 +1,8 @@
+require "celluloid"
+
+module SuchGreatHeights
+  class ServiceSupervisionGroup < Celluloid::SupervisionGroup
+    supervise TileCache, as: :tile_cache
+    supervise Service, as: :service
+  end
+end

--- a/lib/such_great_heights/tile_cache.rb
+++ b/lib/such_great_heights/tile_cache.rb
@@ -3,7 +3,11 @@ module SuchGreatHeights
     include SrtmConversions
     include Celluloid
 
-    def initialize(tile_set, tile_duration, tile_loader: TileLoader)
+    FROM_CONFIG = ->(key) { Configuration.current.public_send(key) }
+
+    def initialize(tile_set: FROM_CONFIG[:tile_set_path],
+                   tile_duration: FROM_CONFIG[:tile_duration],
+                   tile_loader: TileLoader)
       @tile_set      = tile_set
       @loader        = tile_loader
       @cache         = {}

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -4,19 +4,13 @@ describe SuchGreatHeights::Service do
   include SuchGreatHeights::SrtmConversions
 
   let(:cache) { class_double("TileCache") }
-  let(:tile_set) { "/path/to/set" }
-  let(:tile_duration) { 2.0 }
 
-  subject { SuchGreatHeights::Service.new(tile_set, tile_duration, tile_cache: cache) }
+  subject { SuchGreatHeights::Service.new(tile_cache: cache) }
 
   describe "#altitude_for" do
     let(:tile) { instance_double("Tile") }
     let(:longitude) { -42.123123 }
     let(:latitude) { -21.123123 }
-
-    before do
-      expect(cache).to receive(:new_link).with(tile_set, tile_duration).and_return(cache)
-    end
 
     generative do
       data(:latitude) { generate(:integer, min: -90, max: 90) }

--- a/spec/unit/tile_cache_spec.rb
+++ b/spec/unit/tile_cache_spec.rb
@@ -11,7 +11,8 @@ describe SuchGreatHeights::TileCache do
   include SuchGreatHeights::SrtmConversions
 
   subject {
-    SuchGreatHeights::TileCache.new(tile_set, duration, tile_loader: loader)
+    SuchGreatHeights::TileCache.new(tile_set: tile_set, tile_duration: duration,
+                                    tile_loader: loader)
   }
 
   describe "#fetch" do


### PR DESCRIPTION
Caso TileCache ou Service morressem, tudo ia para as cucuias. O
[SupervisionGroup](https://github.com/celluloid/celluloid/wiki/Supervision-Groups) cuida de reiniciá-los corretamente, para que
clientes subsequentes possam continuar felizes sabendo as alturas de
tudo.
